### PR TITLE
Use dev environment file to fix readthedocs build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,7 +2,7 @@ build:
    image: latest
 
 conda:
-   file: docs/env.yml
+   file: ./environment-dev.yml
 
 python:
    version: 3


### PR DESCRIPTION
Most recent build failed due to `pyyaml` missing from old conda env file